### PR TITLE
test(fp): prove the staged multiply leaf ArchF32MulStaged4

### DIFF
--- a/tests/fp_v1/smt_proof/README.md
+++ b/tests/fp_v1/smt_proof/README.md
@@ -346,12 +346,22 @@ composition* of primitives as the comb operator; the primitives' own correctness
 separately by the renderer miters above, at native 32-bit width. Non-vacuity is
 self-checked: corrupting one tree add flips the verdict to `sat`.
 
-**`scaled_quantize` stays `balance-only`** (Lemma A deferred): its per-element
-multiplies are done by staged-multiply *instances* (`ArchF32MulStaged4`), a
-two-level structure the straight-line UF extractor doesn't cover, and its
-parallel-uniform-depth datapath is well covered by balance + the throughput
-lockstep. `scaled_dot` is emittable only for power-of-two block sizes (the type
-checker rejects the rest, arch#960).
+**The shared staged-multiply leaf `ArchF32MulStaged4`** (row `mulstaged4`) gets
+its own Lemma A + Lemma B: it is balanced at latency 3, and its register-shorted
+function equals `arch_f32_mul` — a *single* multiply, so a direct bit-blast miter
+clears in seconds (no split). Every staged block op that instantiates it (the
+eight parallel multiplies of `scaled_quantize`, etc.) therefore builds on a
+proven-correct pipelined multiply.
+
+**`scaled_quantize` stays `balance-only`** at the whole-operator level (Lemma A
+deferred). With the multiply leaf now proven, the remaining gap is only its
+*composition* — a `for`-loop max-reduction to pick the block scale, a `generate`
+array of the (proven) multiply instances, and `? :` special-case narrowing.
+That's beyond the straight-line UF extractor (which handles the `scaled_dot`
+tree); covering it would need loop/generate/conditional elaboration. Balance +
+the throughput lockstep + the proven multiply leaf cover it in the meantime.
+`scaled_dot` is emittable only for power-of-two block sizes (the type checker
+rejects the rest, arch#960).
 
 Composing the pieces, the staged `scaled_dot` equivalence is now machine-checked
 end to end: Lemma A (UF — same composition) ∘ leaf primitive correctness

--- a/tests/fp_v1/smt_proof/staged_ops_miter.sh
+++ b/tests/fp_v1/smt_proof/staged_ops_miter.sh
@@ -82,10 +82,12 @@ DUMP_FP_BIN="${DUMP_FP_BIN:-$(dirname "$ARCH_BIN")/examples/dump_fp}"
 #
 # `L` is the staged *submodule* latency (the user-visible pipe_reg adds one more
 # cycle via the wrapper's reset/valid register, an ordinary pipe_reg cascade).
+# NAME | staged module | L | render_smt fn | mode | args (space-sep in-ports)
 ops=(
-  "fma6|ArchF32FmaStaged6|5|arch_fma_f32|fma"
-  "dot8|arch_scaled_dot_e2m1_8_e8m0_staged6|5|-|uf-dot"
-  "quant8|arch_scaled_quantize_e2m1_8_e8m0_floor_rne_staged5|4|-|balance-only"
+  "fma6|ArchF32FmaStaged6|5|arch_fma_f32|fma|a b c"
+  "mulstaged4|ArchF32MulStaged4|3|arch_f32_mul|mono|a b"
+  "dot8|arch_scaled_dot_e2m1_8_e8m0_staged6|5|-|uf-dot|"
+  "quant8|arch_scaled_quantize_e2m1_8_e8m0_floor_rne_staged5|4|-|balance-only|"
 )
 
 # combinationalize: within a staged submodule's always_ff blocks (which are pure
@@ -105,7 +107,8 @@ combinationalize () { # $1 = infile  $2 = module  $3 = outfile
 echo "# module                                        lemmaB(balance)  lemmaA(arith)    L"
 fail=0
 for spec in "${ops[@]}"; do
-  IFS='|' read -r name mod L fn split <<<"$spec"
+  IFS='|' read -r name mod L fn split args <<<"$spec"
+  [[ -n "${MITER_ONLY:-}" && "$name" != "$MITER_ONLY" ]] && continue
   d="$outdir/$name"; mkdir -p "$d"
 
   # emit the staged SV for this operator
@@ -123,6 +126,25 @@ module ${name}_top
     y@6 <= fma<pipelined, 6>(a, b, c);
   end seq
 end module ${name}_top
+ARCH
+      ;;
+    mulstaged4)
+      # ArchF32MulStaged4 is the shared staged-multiply leaf; it is emitted as a
+      # submodule of any staged block op. Emit a staged quantize and pick it out
+      # with `hierarchy -top ArchF32MulStaged4`.
+      cat > "$d/src.arch" <<'ARCH'
+package QF
+  type B4 = ScaledVec<FP4E2M1, 8, E8M0>;
+end package QF
+module mulstaged4_top
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port v: in Vec<FP32, 8>;
+  port y: out pipe_reg<B4, 5> reset rst => 0;
+  seq on clk rising
+    y@5 <= scaled_quantize<B4, pipelined, 5>(v);
+  end seq
+end module mulstaged4_top
 ARCH
       ;;
     dot8)
@@ -220,14 +242,16 @@ src = re.sub(r'\(define-fun \|%s_t\|[^\n]*\n' % mod, '', src)
 open(f'{d}/comb.qfbv.smt2', 'w').write(src)
 PYSPEC
 
+  # arity-generic: each in-port p -> a define-fun `pp` (a->aa, b->bb, c->cc), and
+  # the spec application `($fn aa bb ...)`. The fma split below reuses aa/bb/cc.
+  argapp=""
   {
     cat "$outdir/arch_defs.smt2" "$d/comb.qfbv.smt2"
-    cat <<SPL
-(define-fun aa () (_ BitVec 32) |${mod}_n a|)
-(define-fun bb () (_ BitVec 32) |${mod}_n b|)
-(define-fun cc () (_ BitVec 32) |${mod}_n c|)
-(assert (not (= |${mod}_n y| ($fn aa bb cc))))
-SPL
+    for p in $args; do
+      echo "(define-fun ${p}${p} () (_ BitVec 32) |${mod}_n $p|)"
+      argapp+=" ${p}${p}"
+    done
+    echo "(assert (not (= |${mod}_n y| ($fn$argapp))))"
   } > "$d/miter_body.smt2"
 
   if [[ "$split" == "fma" ]]; then

--- a/tests/staged_fma_equivalence_miter_test.rs
+++ b/tests/staged_fma_equivalence_miter_test.rs
@@ -345,3 +345,51 @@ fn staged_scaled_dot_uf_arithmetic_equivalence() {
         "UF miter is vacuous — a corrupted tree add did not change the verdict"
     );
 }
+
+/// Both lemmas for the shared staged-multiply leaf `ArchF32MulStaged4` (used by
+/// every staged block op): Lemma B (balanced at latency 3) and Lemma A (the
+/// register-shorted multiply equals `arch_f32_mul` — a single mul, tractable by
+/// direct bit-blast, no split). Runs the `mulstaged4` row of the miter script.
+/// Requires yosys + z3 + python3 + the dump_fp example.
+#[test]
+fn staged_mul_leaf_equivalence() {
+    if !tool_ok("yosys") || !tool_ok("z3") || !tool_ok("python3") {
+        eprintln!("skipping: yosys/z3/python3 not available");
+        return;
+    }
+    let dump_fp = PathBuf::from(env!("CARGO_BIN_EXE_arch"))
+        .parent()
+        .unwrap()
+        .join("examples")
+        .join("dump_fp");
+    if !dump_fp.exists() {
+        eprintln!("skipping: dump_fp example not built");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    let script = repo_root().join("tests/fp_v1/smt_proof/staged_ops_miter.sh");
+    let out = Command::new("bash")
+        .arg(&script)
+        .arg(td.path())
+        .env("ARCH_BIN", env!("CARGO_BIN_EXE_arch"))
+        .env("DUMP_FP_BIN", &dump_fp)
+        .env("MITER_ONLY", "mulstaged4")
+        .env("MITER_TIMEOUT", "300")
+        .output()
+        .expect("run staged_ops_miter.sh");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "staged mul miter FAILED:\n{stdout}\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("ArchF32MulStaged4") && stdout.contains("balanced@3"),
+        "staged mul must be balanced at latency 3:\n{stdout}"
+    );
+    // the Lemma-A column for this row must be a clean `unsat` (not deferred/smoke)
+    assert!(
+        stdout.contains("balanced@3       unsat"),
+        "staged mul register-shorted != arch_f32_mul:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## What

Proves `ArchF32MulStaged4` — the shared staged-multiply leaf every staged block op instantiates (the eight parallel multiplies of `scaled_quantize`, and any future staged block op). Both lemmas:

```
ArchF32MulStaged4   balanced@3   unsat   3
```

- **Lemma B:** balanced feed-forward pipeline, uniform latency 3.
- **Lemma A:** the register-shorted multiply equals `arch_f32_mul` for all inputs. It's a *single* multiply (not a tree), so a direct bit-blast miter against the `render_smt` model clears in ~6s with no split — the reduction tree was what needed UF abstraction, not a lone mul.

So every staged block op now builds on a **proven-correct pipelined multiply**.

## Changes

- `staged_ops_miter.sh`: new `mulstaged4` row. The miter is now **arity-generic** (in-ports come from an `args` field instead of being hardcoded to fma's three), and honors `MITER_ONLY=<row>` to run a single row.
- `staged_mul_leaf_equivalence` test (`balanced@3` + `unsat`) under `cargo test`.

## On `scaled_quantize`

It stays `balance-only` at the whole-operator level. With the multiply leaf now proven, the only remaining gap is its **composition** — a `for`-loop max-reduction to pick the block scale, a `generate` array of the (now proven) multiply instances, and `? :` special-case narrowing. Covering that needs loop/generate/conditional elaboration, beyond the straight-line UF extractor that handles the `scaled_dot` tree. Balance + throughput lockstep + the proven multiply leaf cover it in the meantime.

Full miter test **6/6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)