### PR TITLE
fix(fp): lift power-of-two restriction on staged scaled_dot via delay-balancing (#980)

### DIFF
--- a/doc/ARCH_HDL_Specification.md
+++ b/doc/ARCH_HDL_Specification.md
@@ -978,17 +978,15 @@ type checker reports the required `N` if a different one is written. As with
 otherwise the call lowers to the combinational operator inside the pipe_reg
 cascade (correct latency, un-retimed).
 
-`scaled_dot<pipelined, N>` additionally requires a **power-of-two block size**.
-Its coarse per-level staging pipelines the `f32_add` reduction tree one level
-per stage, which stays latency-balanced only when the tree is perfect — i.e.
-the element count is a power of two. For a non-power-of-two count the tree
-carries an odd element across a round rather than padding with zero (padding
-would turn `-0.0` into `+0.0`, a real value change), so that element crosses
-fewer register edges than its siblings and would reach the scale multiply a
-cycle early. The type checker rejects a non-power-of-two block rather than emit
-a skewed pipeline; the combinational `scaled_dot` (drop `pipelined`) handles any
-`N`. `scaled_quantize` has no such restriction — its per-element multiplies run
-in parallel at a uniform depth.
+`scaled_dot<pipelined, N>` is available for any block size `N`: the coarse
+per-level staging pipelines the `f32_add` reduction tree one level per stage,
+and for a non-power-of-two count the tree carries an odd element across a
+round. The emitter inserts delay-balancing pass-through registers on carried
+paths so every element crosses the same number of stages (registers delay,
+they do not add — unlike zero-padding, which would turn `-0.0` into `+0.0`, a
+real value change). The combinational `scaled_dot` (drop `pipelined`) likewise
+handles any `N`. `scaled_quantize` has no such restriction — its per-element
+multiplies run in parallel at a uniform depth.
 
 **The call's depth is authoritative; the tap is a consistency check.** A
 `<pipelined, N>` call produces a value with latency `N` — it must be bound

--- a/doc/Arch_AI_Reference_Card.md
+++ b/doc/Arch_AI_Reference_Card.md
@@ -296,7 +296,7 @@ scaled_quantize<Fmt, policy, rounding>(v)   // policy ∈ floor_pow2|ceil_pow2|e
 scaled_dequantize(b)                 // block → Vec<FP32,N> (scale applied; the ONLY way to read a lane)
 scaled_dot(a, b)                     // two blocks of the SAME type → FP32 (block dot product, FP32 accumulate)
 scaled_quantize<Fmt, pipelined, N>(v)       // pipelined block quantize (E8M0 only); N is FIXED per shape (a quantize is 5)
-scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8); block size must be a POWER OF TWO. Both need --staged-ops
+scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8, 7 for N=12); any N — emitter delay-balances carried paths. Both need --staged-ops
 a == b   a != b                      // ENCODING compare on the packed word: equal bits ⇒ equal value, but
                                      //   unequal bits ≠ unequal value — dequantize both for a true value test
 ```

--- a/skills/arch-programming/references/ARCH_HDL_Specification.md
+++ b/skills/arch-programming/references/ARCH_HDL_Specification.md
@@ -978,17 +978,15 @@ type checker reports the required `N` if a different one is written. As with
 otherwise the call lowers to the combinational operator inside the pipe_reg
 cascade (correct latency, un-retimed).
 
-`scaled_dot<pipelined, N>` additionally requires a **power-of-two block size**.
-Its coarse per-level staging pipelines the `f32_add` reduction tree one level
-per stage, which stays latency-balanced only when the tree is perfect — i.e.
-the element count is a power of two. For a non-power-of-two count the tree
-carries an odd element across a round rather than padding with zero (padding
-would turn `-0.0` into `+0.0`, a real value change), so that element crosses
-fewer register edges than its siblings and would reach the scale multiply a
-cycle early. The type checker rejects a non-power-of-two block rather than emit
-a skewed pipeline; the combinational `scaled_dot` (drop `pipelined`) handles any
-`N`. `scaled_quantize` has no such restriction — its per-element multiplies run
-in parallel at a uniform depth.
+`scaled_dot<pipelined, N>` is available for any block size `N`: the coarse
+per-level staging pipelines the `f32_add` reduction tree one level per stage,
+and for a non-power-of-two count the tree carries an odd element across a
+round. The emitter inserts delay-balancing pass-through registers on carried
+paths so every element crosses the same number of stages (registers delay,
+they do not add — unlike zero-padding, which would turn `-0.0` into `+0.0`, a
+real value change). The combinational `scaled_dot` (drop `pipelined`) likewise
+handles any `N`. `scaled_quantize` has no such restriction — its per-element
+multiplies run in parallel at a uniform depth.
 
 **The call's depth is authoritative; the tap is a consistency check.** A
 `<pipelined, N>` call produces a value with latency `N` — it must be bound

--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -818,13 +818,58 @@ pub fn sv_staged_dot(s: BlockShape) -> (String, String, u32) {
     }
     let _ = writeln!(o, "  end");
     // reduction tree: one stage per level; reg_of maps a value id to its
-    // current register name.
+    // current register name. Production levels track when each value is
+    // available: products at 0, each add at its level. A value produced at
+    // level j consumed at level k passes through k - j - 1 dummy registers
+    // so every path has equal depth (delay-balancing, #980). Scale bytes
+    // already do this via sda/sdb shift; here we do it for carried dot
+    // elements (odd N) where zero-padding would flip -0.0.
     let mut reg_of: std::collections::HashMap<usize, String> = std::collections::HashMap::new();
+    let mut prod_level: std::collections::HashMap<usize, u32> = std::collections::HashMap::new();
     for i in 0..n as usize {
         reg_of.insert(i, format!("r0_{i}"));
+        prod_level.insert(i, 0);
     }
     for (li, level) in levels.iter().enumerate() {
         let lvl = (li + 1) as u32;
+        // Delay-balance carried inputs before the comb for this level.
+        // Collect the set of values consumed at this level that need
+        // padding, then emit their delay chains in one always_ff.
+        let mut to_delay: Vec<(usize, u32, u32)> = Vec::new(); // (id, from_lvl, to_lvl)
+        for (_, l, r) in level {
+            for &v in &[*l, *r] {
+                if let Some(&j) = prod_level.get(&v) {
+                    if lvl > j + 1 {
+                        to_delay.push((v, j, lvl));
+                    }
+                }
+            }
+        }
+        // Deduplicate by value id (a carried value may be used once, but
+        // be safe) and sort for determinism.
+        {
+            let mut seen = std::collections::HashSet::new();
+            to_delay.retain(|(id, _, _)| seen.insert(*id));
+            to_delay.sort_by_key(|(id, _, _)| *id);
+        }
+        if !to_delay.is_empty() {
+            for (vid, j, k) in &to_delay {
+                for d in (*j + 1)..*k {
+                    let _ = writeln!(o, "  logic {}r{d}_{vid}_d;", sv_w(32));
+                }
+            }
+            let _ = writeln!(o, "  always_ff @(posedge clk) begin");
+            for (vid, j, k) in &to_delay {
+                let mut cur = reg_of[vid].clone();
+                for d in (*j + 1)..*k {
+                    let nxt = format!("r{d}_{vid}_d");
+                    let _ = writeln!(o, "    {nxt} <= {cur};");
+                    cur = nxt;
+                }
+                reg_of.insert(*vid, cur);
+            }
+            let _ = writeln!(o, "  end");
+        }
         for (dst, _, _) in level {
             let _ = writeln!(o, "  logic {}c{lvl}_{dst};", sv_w(32));
         }
@@ -842,6 +887,7 @@ pub fn sv_staged_dot(s: BlockShape) -> (String, String, u32) {
         for (dst, _, _) in level {
             let _ = writeln!(o, "    r{lvl}_{dst} <= c{lvl}_{dst};");
             reg_of.insert(*dst, format!("r{lvl}_{dst}"));
+            prod_level.insert(*dst, lvl);
         }
         let _ = writeln!(o, "  end");
     }

--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -846,9 +846,10 @@ pub fn sv_staged_dot(s: BlockShape) -> (String, String, u32) {
             }
         }
         // Deduplicate by value id (a carried value may be used once, but
-        // be safe) and sort for determinism.
+        // be safe) and sort for determinism. BTreeSet makes iteration
+        // order deterministic without relying on HashSet's randomized hash.
         {
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = std::collections::BTreeSet::new();
             to_delay.retain(|(id, _, _)| seen.insert(*id));
             to_delay.sort_by_key(|(id, _, _)| *id);
         }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -4221,30 +4221,13 @@ impl<'a> TypeChecker<'a> {
                 return Ty::Error;
             }
             // The coarse per-level staging pipelines the `f32_add` reduction
-            // tree one level per stage. That is latency-uniform only when the
-            // tree is perfectly balanced — i.e. a power-of-two block size. For a
-            // non-power-of-two count, `dot_schedule` carries an odd element
-            // across a round rather than padding with zero (padding would turn
-            // -0.0 into +0.0), so that element crosses fewer register edges than
-            // its siblings and reaches the scale multiply a cycle early — a
-            // silent miscompile invisible to stable-input testing (the
-            // structural balance check in tests/fp_v1/synth/pipeline_balance.py
-            // reports it as UNBALANCED [k-1, k]). Reject it rather than emit a
-            // skewed pipeline; the combinational `scaled_dot` handles any N.
-            if !(*an).is_power_of_two() {
-                self.errors.push(CompileError::general(
-                    &format!(
-                        "`scaled_dot<pipelined, N>` requires a power-of-two block size, got \
-                         {an}. The staged reduction tree only stays latency-balanced when every \
-                         element crosses the same number of adder stages; a non-power-of-two \
-                         block carries an odd element across levels and skews the pipeline. Use a \
-                         power-of-two block size, or the combinational `scaled_dot` (drop \
-                         `pipelined`), which handles any N."
-                    ),
-                    span,
-                ));
-                return Ty::Error;
-            }
+            // tree one level per stage. Formerly this was latency-uniform only
+            // for power-of-two block sizes — a non-power-of-two count carries
+            // an odd element across levels. The emitter now inserts
+            // delay-balancing pass-through registers on carried paths (registers
+            // delay, they do not add — unlike zero-padding, which would flip
+            // `-0.0` to `+0.0`), so every element crosses the same number of
+            // stages. See `fp_block::sv_staged_dot` and issue #980.
             let want = crate::fp_block::staged_dot_binding_latency(*an);
             if stages != want {
                 self.errors.push(CompileError::general(

--- a/tests/staged_dot_lockstep_test.rs
+++ b/tests/staged_dot_lockstep_test.rs
@@ -159,12 +159,14 @@ fn staged_dot_throughput_lockstep_verilator() {
     );
 }
 
-// ── Power-of-two block-size guard (typecheck) ───────────────────────────────
-// The coarse per-level staging pipelines the reduction tree one level per
-// stage, which is latency-balanced only for a power-of-two block size. A
-// non-power-of-two count carries an odd element across levels and skews the
-// pipeline (a silent miscompile invisible to stable-input testing — the
-// structural balance check reports UNBALANCED). The type checker rejects it.
+// ── Power-of-two restriction lifted by delay-balancing (#980) ─────────────
+// Formerly the coarse per-level staging was latency-balanced only for
+// power-of-two block sizes; a non-power-of-two count carried an odd element
+// across levels and skewed the pipeline. The emitter now inserts
+// delay-balancing pass-through registers on carried paths (registers delay,
+// they do not add), so every element crosses the same number of stages.
+// The power-of-two guard is removed; the balance check below must report
+// BALANCED for former UNBALANCED shapes.
 
 /// Build `scaled_dot<pipelined, N>` over a block of `n` elements at latency
 /// `lat`; return the combined `arch check` output and whether it succeeded.
@@ -194,26 +196,156 @@ fn check_dot(n: u32, lat: u32) -> (bool, String) {
 
 #[test]
 fn staged_dot_rejects_non_power_of_two_block() {
-    // N=8 (tree depth 3, latency 6) is a power of two → accepted.
+    // Power-of-two restriction lifted (#980): N=6,12 now accepted via
+    // delay-balancing registers. This test is retained as an acceptance
+    // check (was a rejection test pre-#980).
     let (ok8, _) = check_dot(8, 6);
     assert!(ok8, "power-of-two block size (8) must be accepted");
-
-    // N=6 is not a power of two → rejected with the power-of-two message,
-    // NOT silently emitted as a skewed pipeline.
     let (ok6, out6) = check_dot(6, 6);
-    assert!(
-        !ok6,
-        "non-power-of-two block size (6) must be rejected:\n{out6}"
-    );
-    assert!(
-        out6.contains("power-of-two block size"),
-        "rejection must name the power-of-two rule:\n{out6}"
-    );
-
-    // N=12 too (a larger non-power-of-two).
+    assert!(ok6, "non-power-of-two block size (6) must be accepted after #980:\n{out6}");
     let (ok12, out12) = check_dot(12, 7);
+    assert!(ok12, "non-power-of-two block size (12) must be accepted after #980:\n{out12}");
+}
+
+// N=6 throughput lockstep — the non-pow2 shape that previously skewed
+// (arch#960). Mirrors staged_dot_throughput_lockstep_verilator but for
+// B6 = ScaledVec<FP4E2M1, 6, E8M0> (bits = 8 + 6*4 = 32, latency 6).
+const SRC6: &str = r#"
+package DF
+  type B6 = ScaledVec<FP4E2M1, 6, E8M0>;
+end package DF
+module PD6
+  port clk: in Clock<Sys>;
+  port rst: in Reset<Sync, High>;
+  port a: in B6;
+  port b: in B6;
+  port o: out pipe_reg<FP32, 6> reset rst => 0.0;
+  seq on clk rising
+    o@6 <= scaled_dot<pipelined, 6>(a, b);
+  end seq
+end module PD6
+"#;
+
+#[test]
+fn staged_dot_throughput_lockstep_verilator_n6() {
+    if !verilator_available() {
+        eprintln!("verilator not in PATH; skipping staged-dot N=6 throughput lockstep");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    let ap = td.path().join("PD6.arch");
+    std::fs::write(&ap, SRC6).unwrap();
+    let build = |staged: bool| -> String {
+        let out = td.path().join(if staged { "s6.sv" } else { "c6.sv" });
+        let mut c = arch();
+        c.arg("build")
+            .arg(&ap)
+            .arg("-o")
+            .arg(&out)
+            .arg("--no-auto-asserts");
+        if staged {
+            c.arg("--staged-ops");
+        }
+        let o = c.output().expect("arch build");
+        assert!(
+            o.status.success(),
+            "arch build failed:\n{}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        std::fs::read_to_string(&out).unwrap()
+    };
+    let cascade = build(false);
+    let staged = build(true);
+    // Reuse combine logic but for PD6/B6 (32-bit blocks → [31:0])
+    let ci = cascade.find("\nmodule PD6").expect("cascade module PD6");
+    let lib = &cascade[..ci];
+    let pq_ca = cascade[ci..]
+        .replacen("module PD6 ", "module PD6_ca ", 1)
+        .replacen("module PD6(", "module PD6_ca(", 1);
+    let si = staged
+        .find("module arch_scaled_dot")
+        .expect("staged dot module");
+    let pj = staged.find("\nmodule PD6").expect("staged module PD6");
+    let sm = &staged[si..pj];
+    let pq_st = staged[pj..]
+        .replacen("module PD6 ", "module PD6_st ", 1)
+        .replacen("module PD6(", "module PD6_st(", 1);
+    let wrap = "module Wrap(input logic clk, input logic rst, input logic [31:0] a, \
+                input logic [31:0] b, output logic [31:0] os, output logic [31:0] oc);\n\
+                \x20 PD6_st st(.clk(clk),.rst(rst),.a(a),.b(b),.o(os));\n\
+                \x20 PD6_ca ca(.clk(clk),.rst(rst),.a(a),.b(b),.o(oc));\nendmodule\n";
+    let combined = {
+        let lib_and_sm = format!("{lib}\n{sm}\n");
+        let pq = format!("{pq_ca}\n{pq_st}\n{wrap}");
+        let mut out = String::new();
+        let mut rest = format!("{lib_and_sm}{pq}");
+        let mut tmp = String::new();
+        let mut rem = rest.as_str();
+        while let Some(p) = rem.find("package DF;") {
+            tmp.push_str(&rem[..p]);
+            let after = &rem[p..];
+            let e = after
+                .find("endpackage")
+                .map(|e| e + "endpackage".len())
+                .unwrap_or(after.len());
+            rem = &after[e..];
+        }
+        tmp.push_str(rem);
+        tmp
+    };
+    let sv = td.path().join("combined6.sv");
+    std::fs::write(&sv, combined).unwrap();
+    const TB6: &str = r#"#include "VWrap.h"
+#include "verilated.h"
+#include <cstdio>
+#include <cstdlib>
+int main(int c,char**v){ Verilated::commandArgs(c,v); VWrap*d=new VWrap;
+  auto tick=[&](){d->clk=0;d->eval();d->clk=1;d->eval();};
+  auto vscale=[&]()->uint64_t{return 0x40+(rand()%0x7E);};
+  auto setab=[&](){ d->a=(vscale()<<24)|(((uint64_t)rand())&0xFFFFFFULL); d->b=(vscale()<<24)|(((uint64_t)rand())&0xFFFFFFULL); };
+  d->rst=1; for(int i=0;i<8;i++){setab();tick();} d->rst=0;
+  for(int i=0;i<16;i++){setab();tick();}
+  int mism=0; unsigned long long nz=0;
+  for(int i=0;i<3000;i++){ setab(); tick(); if(d->oc!=0)nz++;
+    if(d->os!=d->oc){ mism++; if(mism<6) printf("MISM i=%d os=%08x oc=%08x\n",i,d->os,d->oc); } }
+  printf("DOTDONE mism=%d nonzero=%llu\n", mism, nz);
+  delete d; return mism==0?0:1; }
+"#;
+    let tb = td.path().join("tb6.cpp");
+    std::fs::write(&tb, TB6).unwrap();
+    let obj = td.path().join("obj_dir6");
+    let vout = Command::new("verilator")
+        .args([
+            "--cc",
+            "--exe",
+            "--build",
+            "--sv",
+            "-Wno-fatal",
+            "-Wno-WIDTH",
+            "-Wno-UNOPTFLAT",
+            "--top-module",
+            "Wrap",
+            "-Mdir",
+        ])
+        .arg(&obj)
+        .arg(&sv)
+        .arg(&tb)
+        .output()
+        .expect("verilate");
     assert!(
-        !ok12,
-        "non-power-of-two block size (12) must be rejected:\n{out12}"
+        vout.status.success(),
+        "verilate N=6 failed:\n{}\n{}",
+        String::from_utf8_lossy(&vout.stdout),
+        String::from_utf8_lossy(&vout.stderr)
+    );
+    let run = Command::new(obj.join("VWrap")).output().expect("run");
+    let txt = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success(),
+        "staged dot N=6 throughput lockstep FAILED:\n{txt}"
+    );
+    assert!(
+        txt.contains("nonzero=") && !txt.contains("nonzero=0\n"),
+        "sim produced no non-zero output (vacuous):\n{txt}"
     );
 }

--- a/tests/staged_dot_lockstep_test.rs
+++ b/tests/staged_dot_lockstep_test.rs
@@ -195,16 +195,21 @@ fn check_dot(n: u32, lat: u32) -> (bool, String) {
 }
 
 #[test]
-fn staged_dot_rejects_non_power_of_two_block() {
+fn staged_dot_accepts_non_power_of_two_block() {
     // Power-of-two restriction lifted (#980): N=6,12 now accepted via
-    // delay-balancing registers. This test is retained as an acceptance
-    // check (was a rejection test pre-#980).
+    // delay-balancing registers. Retained as acceptance (was rejection pre-#980).
     let (ok8, _) = check_dot(8, 6);
     assert!(ok8, "power-of-two block size (8) must be accepted");
     let (ok6, out6) = check_dot(6, 6);
     assert!(ok6, "non-power-of-two block size (6) must be accepted after #980:\n{out6}");
     let (ok12, out12) = check_dot(12, 7);
     assert!(ok12, "non-power-of-two block size (12) must be accepted after #980:\n{out12}");
+}
+
+#[test]
+fn staged_dot_rejects_non_power_of_two_block() {
+    // Back-compat shim: old name now aliases the acceptance test.
+    staged_dot_accepts_non_power_of_two_block()
 }
 
 // N=6 throughput lockstep — the non-pow2 shape that previously skewed

--- a/tests/staged_fma_equivalence_miter_test.rs
+++ b/tests/staged_fma_equivalence_miter_test.rs
@@ -188,9 +188,8 @@ fn assert_staged_balanced(src: &str, module: &str, expect: u32) {
 
 /// Lemma B for the staged `scaled_dot` block operator (arch#955): the N products
 /// → `f32_add` reduction tree → scale multiplies must form a balanced pipeline.
-/// This is the exact check that catches the non-power-of-two skew of arch#960
-/// (there the type checker now rejects non-power-of-two sizes; a power-of-two
-/// block must stay balanced).
+/// Formerly this caught the non-power-of-two skew of arch#960; after #980 the
+/// emitter delay-balances carried odd elements so every N is balanced.
 #[test]
 fn staged_scaled_dot_is_balanced() {
     assert_staged_balanced(
@@ -202,6 +201,48 @@ fn staged_scaled_dot_is_balanced() {
          end module Dot\n",
         "arch_scaled_dot_e2m1_8_e8m0_staged6",
         5,
+    );
+}
+
+#[test]
+fn staged_scaled_dot_is_balanced_n5() {
+    assert_staged_balanced(
+        "package DF\n  type B5 = ScaledVec<FP4E2M1, 5, E8M0>;\nend package DF\n\
+         module Dot5\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync, High>;\n\
+         \x20 port a: in B5;\n  port b: in B5;\n\
+         \x20 port o: out pipe_reg<FP32, 6> reset rst => 0.0;\n\
+         \x20 seq on clk rising\n    o@6 <= scaled_dot<pipelined, 6>(a, b);\n  end seq\n\
+         end module Dot5\n",
+        "arch_scaled_dot_e2m1_5_e8m0_staged6",
+        5,
+    );
+}
+
+#[test]
+fn staged_scaled_dot_is_balanced_n6() {
+    assert_staged_balanced(
+        "package DF\n  type B6 = ScaledVec<FP4E2M1, 6, E8M0>;\nend package DF\n\
+         module Dot6\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync, High>;\n\
+         \x20 port a: in B6;\n  port b: in B6;\n\
+         \x20 port o: out pipe_reg<FP32, 6> reset rst => 0.0;\n\
+         \x20 seq on clk rising\n    o@6 <= scaled_dot<pipelined, 6>(a, b);\n  end seq\n\
+         end module Dot6\n",
+        "arch_scaled_dot_e2m1_6_e8m0_staged6",
+        5,
+    );
+}
+
+#[test]
+fn staged_scaled_dot_is_balanced_n12() {
+    assert_staged_balanced(
+        "package DF\n  type B12 = ScaledVec<FP4E2M1, 12, E8M0>;\nend package DF\n\
+         module Dot12\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync, High>;\n\
+         \x20 port a: in B12;\n  port b: in B12;\n\
+         \x20 port o: out pipe_reg<FP32, 7> reset rst => 0.0;\n\
+         \x20 seq on clk rising\n    o@7 <= scaled_dot<pipelined, 7>(a, b);\n  end seq\n\
+         end module Dot12\n",
+        "arch_scaled_dot_e2m1_12_e8m0_staged7",
+        6,
     );
 }
 
@@ -343,6 +384,76 @@ fn staged_scaled_dot_uf_arithmetic_equivalence() {
         run(&["--mutate", "add-operand"]),
         "sat",
         "UF miter is vacuous — a corrupted tree add did not change the verdict"
+    );
+}
+
+#[test]
+fn staged_scaled_dot_n6_uf_arithmetic_equivalence() {
+    if !tool_ok("z3") || !tool_ok("python3") {
+        eprintln!("skipping: z3/python3 not available");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    // N=6 staged design — the non-pow2 shape that previously skewed
+    let staged_src = "package DF\n  type B6 = ScaledVec<FP4E2M1, 6, E8M0>;\nend package DF\n\
+        module Dot6\n  port clk: in Clock<Sys>;\n  port rst: in Reset<Sync, High>;\n\
+        \x20 port a: in B6;\n  port b: in B6;\n\
+        \x20 port o: out pipe_reg<FP32, 6> reset rst => 0.0;\n\
+        \x20 seq on clk rising\n    o@6 <= scaled_dot<pipelined, 6>(a, b);\n  end seq\n\
+        end module Dot6\n";
+    let comb_src = "package DF\n  type B6 = ScaledVec<FP4E2M1, 6, E8M0>;\nend package DF\n\
+        module DotC6\n  port a: in B6;\n  port b: in B6;\n  port o: out FP32;\n\
+        \x20 comb o = scaled_dot(a, b); end comb\nend module DotC6\n";
+    let sa = td.path().join("dot6.arch");
+    let ca = td.path().join("dotc6.arch");
+    std::fs::write(&sa, staged_src).unwrap();
+    std::fs::write(&ca, comb_src).unwrap();
+    let ssv = td.path().join("staged6.sv");
+    let csv = td.path().join("comb6.sv");
+    assert!(arch()
+        .args(["build", "--staged-ops"])
+        .arg(&sa)
+        .arg("-o")
+        .arg(&ssv)
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(arch()
+        .arg("build")
+        .arg(&ca)
+        .arg("-o")
+        .arg(&csv)
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let driver = repo_root().join("tests/fp_v1/synth/uf_datapath.py");
+    let run = |extra: &[&str]| -> String {
+        let mut c = Command::new("python3");
+        c.arg(&driver)
+            .arg(&csv)
+            .arg("arch_scaled_dot_e2m1_6_e8m0")
+            .arg(&ssv)
+            .arg("arch_scaled_dot_e2m1_6_e8m0_staged6");
+        for e in extra {
+            c.arg(e);
+        }
+        String::from_utf8_lossy(&c.output().expect("run uf_datapath.py").stdout)
+            .trim()
+            .to_string()
+    };
+
+    assert_eq!(
+        run(&[]),
+        "unsat",
+        "staged N=6 scaled_dot must match comb operator (delay-balanced)"
+    );
+    assert_eq!(
+        run(&["--mutate", "add-operand"]),
+        "sat",
+        "UF miter vacuous for N=6"
     );
 }
 


### PR DESCRIPTION
Closes #980.

- Emitter `fp_block.rs::sv_staged_dot` now tracks production levels and inserts `k-j-1` pass-through registers for values carried across levels (dummy regs, reset-free). Fixes silent miscompile for non-pow2 N (e.g. N=6,12) where odd element reached scale mul a cycle early.

- Typecheck `typecheck.rs` removes power-of-two rejection; now accepts any N with correct latency `1+tree_depth+1+1`.

- Tests: repurpose `staged_dot_rejects_non_power_of_two_block` to acceptance, add N=6 throughput lockstep (mirrors staged_dot_lockstep_test), add balance checks for N=5,6,12 and UF miter for N=6.

- Docs: spec §3.8a and reference card updated to describe delay-balancing (registers delay, not add).

Verified: staged_dot N=6,8 throughput lockstep and N=5,6,12 balance and N=6 UF all pass; existing N=8 behavior unchanged.