### PR TITLE
fix(review): PR #982 follow-ups — remove rejects alias, add double-consume debug_assert

### DIFF
--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -845,6 +845,26 @@ pub fn sv_staged_dot(s: BlockShape) -> (String, String, u32) {
                 }
             }
         }
+        // Carried values are consumed exactly once in a tree; double-
+        // consumption at different levels would double-declare the same
+        // `_d` chain. Guard for future schedule generalizations.
+        debug_assert!(
+            {
+                let mut seen: std::collections::HashMap<usize, (u32, u32)> =
+                    std::collections::HashMap::new();
+                let mut ok = true;
+                for (id, j, k) in &to_delay {
+                    if let Some((pj, pk)) = seen.insert(*id, (*j, *k)) {
+                        if pj != *j || pk != *k {
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                ok
+            },
+            "double-consumption of carried value at different levels would double-declare _d registers"
+        );
         // Deduplicate by value id (a carried value may be used once, but
         // be safe) and sort for determinism. BTreeSet makes iteration
         // order deterministic without relying on HashSet's randomized hash.

--- a/tests/staged_dot_lockstep_test.rs
+++ b/tests/staged_dot_lockstep_test.rs
@@ -206,12 +206,6 @@ fn staged_dot_accepts_non_power_of_two_block() {
     assert!(ok12, "non-power-of-two block size (12) must be accepted after #980:\n{out12}");
 }
 
-#[test]
-fn staged_dot_rejects_non_power_of_two_block() {
-    // Back-compat shim: old name now aliases the acceptance test.
-    staged_dot_accepts_non_power_of_two_block()
-}
-
 // N=6 throughput lockstep — the non-pow2 shape that previously skewed
 // (arch#960). Mirrors staged_dot_throughput_lockstep_verilator but for
 // B6 = ScaledVec<FP4E2M1, 6, E8M0> (bits = 8 + 6*4 = 32, latency 6).


### PR DESCRIPTION
Follow-up to #982 flagged nits:

1. `staged_dot_rejects_non_power_of_two_block` survived as a back-compat alias that now asserts acceptance — confusing. Deleted (test names aren't an API).

2. Latent double-consumption at different levels would double-declare `_d` registers — impossible while `dot_schedule` is a tree, but worth a `debug_assert` if schedule generalizes. Added HashMap check before BTreeSet dedup in `src/fp_block.rs:851`.

No functional change for pow2 N; N=5,6,12 balance and N=6 UF/throughput still green.