### PR TITLE
fix(review): green main after #983 — fmt, stale snapshot, real double-consume guard

### DIFF
--- a/skills/arch-programming/references/Arch_AI_Reference_Card.md
+++ b/skills/arch-programming/references/Arch_AI_Reference_Card.md
@@ -296,7 +296,7 @@ scaled_quantize<Fmt, policy, rounding>(v)   // policy ∈ floor_pow2|ceil_pow2|e
 scaled_dequantize(b)                 // block → Vec<FP32,N> (scale applied; the ONLY way to read a lane)
 scaled_dot(a, b)                     // two blocks of the SAME type → FP32 (block dot product, FP32 accumulate)
 scaled_quantize<Fmt, pipelined, N>(v)       // pipelined block quantize (E8M0 only); N is FIXED per shape (a quantize is 5)
-scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8); block size must be a POWER OF TWO. Both need --staged-ops
+scaled_dot<pipelined, N>(a, b)              // pipelined block dot (E8M0 only); N FIXED = 3 + tree-depth (6 for N=8, 7 for N=12); any N — emitter delay-balances carried paths. Both need --staged-ops
 a == b   a != b                      // ENCODING compare on the packed word: equal bits ⇒ equal value, but
                                      //   unequal bits ≠ unequal value — dequantize both for a true value test
 ```

--- a/src/fp_block.rs
+++ b/src/fp_block.rs
@@ -830,6 +830,15 @@ pub fn sv_staged_dot(s: BlockShape) -> (String, String, u32) {
         reg_of.insert(i, format!("r0_{i}"));
         prod_level.insert(i, 0);
     }
+    // Values that have already had a `_d` delay chain emitted, across ALL
+    // levels. `dot_schedule` builds a tree (each value consumed exactly once),
+    // so a second chain for the same id is unreachable today — but if a future
+    // schedule ever consumed a carried value at two different levels, the
+    // second chain would re-declare the same `r{d}_{id}_d` registers (an SV
+    // compile error at best, a silent stale read at worst, since `prod_level`
+    // is not advanced after delaying). Guard it loudly here, at emission,
+    // where the hazard actually lives.
+    let mut delayed_ids: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
     for (li, level) in levels.iter().enumerate() {
         let lvl = (li + 1) as u32;
         // Delay-balance carried inputs before the comb for this level.
@@ -845,26 +854,6 @@ pub fn sv_staged_dot(s: BlockShape) -> (String, String, u32) {
                 }
             }
         }
-        // Carried values are consumed exactly once in a tree; double-
-        // consumption at different levels would double-declare the same
-        // `_d` chain. Guard for future schedule generalizations.
-        debug_assert!(
-            {
-                let mut seen: std::collections::HashMap<usize, (u32, u32)> =
-                    std::collections::HashMap::new();
-                let mut ok = true;
-                for (id, j, k) in &to_delay {
-                    if let Some((pj, pk)) = seen.insert(*id, (*j, *k)) {
-                        if pj != *j || pk != *k {
-                            ok = false;
-                            break;
-                        }
-                    }
-                }
-                ok
-            },
-            "double-consumption of carried value at different levels would double-declare _d registers"
-        );
         // Deduplicate by value id (a carried value may be used once, but
         // be safe) and sort for determinism. BTreeSet makes iteration
         // order deterministic without relying on HashSet's randomized hash.
@@ -875,6 +864,12 @@ pub fn sv_staged_dot(s: BlockShape) -> (String, String, u32) {
         }
         if !to_delay.is_empty() {
             for (vid, j, k) in &to_delay {
+                let _fresh = delayed_ids.insert(*vid);
+                debug_assert!(
+                    _fresh,
+                    "value {vid} needs a second delay chain (consumed at two \
+                     different levels) — would re-declare its `_d` registers"
+                );
                 for d in (*j + 1)..*k {
                     let _ = writeln!(o, "  logic {}r{d}_{vid}_d;", sv_w(32));
                 }

--- a/tests/staged_dot_lockstep_test.rs
+++ b/tests/staged_dot_lockstep_test.rs
@@ -201,9 +201,15 @@ fn staged_dot_accepts_non_power_of_two_block() {
     let (ok8, _) = check_dot(8, 6);
     assert!(ok8, "power-of-two block size (8) must be accepted");
     let (ok6, out6) = check_dot(6, 6);
-    assert!(ok6, "non-power-of-two block size (6) must be accepted after #980:\n{out6}");
+    assert!(
+        ok6,
+        "non-power-of-two block size (6) must be accepted after #980:\n{out6}"
+    );
     let (ok12, out12) = check_dot(12, 7);
-    assert!(ok12, "non-power-of-two block size (12) must be accepted after #980:\n{out12}");
+    assert!(
+        ok12,
+        "non-power-of-two block size (12) must be accepted after #980:\n{out12}"
+    );
 }
 
 // N=6 throughput lockstep — the non-pow2 shape that previously skewed


### PR DESCRIPTION
## What

#983 was merged over two red checks, leaving **main failing CI** on:
- `cargo fmt --check` — #983's test edits were unformatted;
- `skill snapshots in sync` — the skills copy of the **reference card** was never re-synced after #982's power-of-two edit (#982 synced the skills *spec* but missed the card; #983 inherited it).

Both fixed (fmt + `sync_skill_snapshots.sh refresh`).

## Also: the #983 debug_assert was vacuous

It scanned for duplicate ids within **one level's** `to_delay` — where a repeated id necessarily has identical `(j, k)` (`j` from `prod_level`, `k` = the level), so the assert **could never fire**. The actual hazard it was meant to guard — the same carried value chained at two *different* levels, re-declaring its `r{d}_{id}_d` registers — happens across loop iterations, invisible to a per-level scan.

Replaced with a guard where the hazard lives: a module-wide `delayed_ids: BTreeSet`, asserted fresh at each chain emission. Unreachable while `dot_schedule` builds a tree (single consumer per value); loud if a future schedule generalizes. The insert is unconditional so release builds carry no unused-variable warning.

## Verification

- `cargo fmt --check` clean; snapshots **9/9 in sync**.
- `staged_dot_lockstep_test` 3/3 in **both debug** (the new assert exercised on N=6/8/12 emissions — silent, correctly) **and release**; miter guards **10/10**.

Main is red until this lands — same-day per the fix-PR lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)