### PR TITLE
codegen(arbiter): declare the ready one-hot internally for valid_only request channels

### DIFF
--- a/src/codegen/arbiter.rs
+++ b/src/codegen/arbiter.rs
@@ -143,6 +143,24 @@ impl<'a> Codegen<'a> {
             ("request_valid".to_string(), "request_ready".to_string())
         };
 
+        // A `valid_only` request channel has no ready port, but every
+        // grant emitter below still drives the per-requester ready
+        // one-hot (`<req>_ready = grant_onehot;` etc.). Keep that name
+        // alive as an internal wire so the emitters stay uniform and the
+        // SV elaborates; nothing outside the module can observe it.
+        let has_ready_port = a
+            .port_arrays
+            .first()
+            .map(|pa| pa.signals.iter().any(|s| s.direction == Direction::Out))
+            .unwrap_or(true);
+        if !has_ready_port {
+            self.line(&format!(
+                "logic [{}] {req_ready_sig};",
+                Self::fold_width_str(&num_req_default)
+            ));
+            self.line("");
+        }
+
         let latency = a.latency;
         let policy = a.policy.clone();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3905,6 +3905,70 @@ end arbiter HsArbSvaVOnly
     );
 }
 
+/// A `valid_only` *request* channel on an arbiter has no ready port at
+/// all, yet the grant emitters drive `<req>_ready` (the per-requester
+/// grant one-hot). The emitted SV referenced an undeclared
+/// `request_ready` and failed to elaborate ("Can't find definition of
+/// variable"). The ready one-hot must be kept as an internal wire; no
+/// ready port and no Tier-2 property may appear.
+#[test]
+fn test_arbiter_valid_only_request_channel_keeps_internal_ready() {
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+arbiter VOnlyReqArb
+  policy round_robin;
+  param NUM_REQ: const = 4;
+  port clk: in Clock<SysDomain>;
+  port rst: in Reset<Sync>;
+  handshake_channel request[NUM_REQ]: receive kind: valid_only
+  end handshake_channel request
+  port grant_valid: out Bool;
+  port grant_requester: out UInt<2>;
+end arbiter VOnlyReqArb
+"#;
+    let sv = compile_to_sv(source);
+    assert!(
+        sv.contains("input logic [NUM_REQ-1:0] request_valid"),
+        "request_valid port expected:\n{sv}"
+    );
+    assert!(
+        !sv.contains("output logic [NUM_REQ-1:0] request_ready"),
+        "valid_only must not expose a ready port:\n{sv}"
+    );
+    assert!(
+        sv.contains("logic [NUM_REQ-1:0] request_ready;"),
+        "ready one-hot must be declared as an internal wire:\n{sv}"
+    );
+    assert!(
+        !sv.contains("_auto_hs_request"),
+        "valid_only request channel must not emit Tier-2 SVA:\n{sv}"
+    );
+    // The SV must elaborate: every reference to request_ready is now declared.
+    if let Ok(vl) = std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+    {
+        if vl.status.success() {
+            let td = tempfile::tempdir().unwrap();
+            let f = td.path().join("VOnlyReqArb.sv");
+            std::fs::write(&f, &sv).unwrap();
+            let out = std::process::Command::new("verilator")
+                .args(["--lint-only", "-Wno-fatal", "--top-module", "VOnlyReqArb"])
+                .arg(&f)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "verilator lint failed:\n{}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+    }
+}
+
 /// A `valid_ready` `handshake_channel` declared *without* any payload
 /// fields must still emit the control-signal `valid_stable` property
 /// (the protocol invariant binds on valid/ready alone). This mirrors


### PR DESCRIPTION
## Problem

An arbiter whose request port is declared `handshake_channel request[N]: receive kind: valid_only` has no ready port (the variant has no back-signal), yet every grant emitter still drives the per-requester ready one-hot (`request_ready = grant_onehot;` for `policy <fn>`, and the round-robin / priority / lock-hold paths likewise). The emitted SV referenced an undeclared `request_ready` and Verilator failed with `Can't find definition of variable: 'request_ready'`.

## Fix

When the request channel exposes no ready signal, declare the one-hot as an internal `logic [N-1:0] request_ready;` (same width expression the port list uses). Nothing outside the module can observe it and the emitters stay uniform across variants. Internal change only.

## Why

arch-ibex's icache drives an age-ordered arbiter with fill-buffer bus requests that are legitimately withdrawn (stale line, IC1 hit, bus error) — a level-sensitive request mask, which is what `valid_only` describes and what upstream Ibex does (`ibex_icache.sv:755,841`). With `valid_ready` the Tier-2 `valid_stable` property fired on every boot; switching the port to `valid_only` then hit this emitter bug.

## Test

`tests/integration_test.rs::test_arbiter_valid_only_request_channel_keeps_internal_ready`: no ready port, internal ready wire present, no Tier-2 SVA, and `verilator --lint-only` clean when Verilator is installed. Fails before this change, passes after. Full `cargo test --release` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)