### PR TITLE
Prepare ARCH 0.72.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.71.0"
+version = "0.72.0"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.71.0"
+version = "0.72.0"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"


### PR DESCRIPTION
Bumps the crate version to 0.72.0 (`Cargo.toml`, `Cargo.lock`). Once merged, the annotated tag `v0.72.0` on the merge commit triggers the cargo-dist release workflow.

**What ships since v0.71.0** (233 commits on `main`, 29 `feat`, 80 `fix`): the `auto;` auto-connect directive (#924), the pipelined FP block operators and checked FP add work (#955, #957, #960, #966, #972), NVFP4 / UE4M3 block scales (#905, #908), expanded native cocotb compatibility, plus today's two fixes found by the arch-ibex reviewer package: interface stubs are no longer variant-mangled (#993) and `valid_only` arbiter request channels keep their internal ready one-hot (#994).

**Known state of `main`:** push CI is green; the `nightly-portability` workflow ("Fail if drift detected") has failed every night since at least 2026-08-25, i.e. it predates everything in this release and is not addressed here.

Version choice: minor bump, following the 0.70.x → 0.71.0 convention for feature-bearing releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)