### PR TITLE
lowering: no declaration initializer on the thread, lock and TLM registers (closes #995)

### DIFF
--- a/src/elaborate/threads.rs
+++ b/src/elaborate/threads.rs
@@ -619,7 +619,7 @@ fn lower_module_threads(
             merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
                 name: Ident::new(format!("_{}_release_{}", res_name, ti), sp),
                 ty: TypeExpr::Bool,
-                init: Some(make_zero_expr(sp)),
+                init: None, // reset-initialised; no declaration initializer (issue #995)
                 reset: RegReset::Inherit(Ident::new(rst_name.clone(), sp), make_zero_expr(sp)),
                 guard: None,
                 multicycle: None,
@@ -673,7 +673,7 @@ fn lower_module_threads(
                 merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
                     name: Ident::new(format!("_{}_held_{}", res_name, ti), sp),
                     ty: TypeExpr::Bool,
-                    init: Some(make_zero_expr(sp)),
+                    init: None, // reset-initialised; no declaration initializer (issue #995)
                     reset: RegReset::Inherit(Ident::new(rst_name.clone(), sp), make_zero_expr(sp)),
                     guard: None,
                     multicycle: None,
@@ -1528,7 +1528,7 @@ fn lower_module_threads(
                 ExprKind::Literal(LitKind::Dec(state_bits.max(1))),
                 sp,
             ))),
-            init: Some(make_zero_expr(sp)),
+            init: None, // reset-initialised; no declaration initializer (issue #995)
             reset: RegReset::Inherit(Ident::new(rst_name.clone(), sp), make_zero_expr(sp)),
             guard: None,
             multicycle: None,
@@ -2205,8 +2205,10 @@ fn lower_module_threads(
             merged_body.push(ModuleBodyItem::RegDecl(RegDecl {
                 name: Ident::new(format!("_t{}_cnt", ti), sp),
                 ty: TypeExpr::UInt(Box::new(Expr::new(ExprKind::Literal(LitKind::Dec(32)), sp))),
-                init: Some(make_zero_expr(sp)),
-                reset: RegReset::None,
+                // Reset with the thread (issue #995): the counter lives in the thread's
+                // reset branch; the lowering adds no declaration initializer.
+                init: None,
+                reset: RegReset::Inherit(Ident::new(t.reset.name.clone(), sp), make_zero_expr(sp)),
                 guard: None,
                 multicycle: None,
                 span: sp,
@@ -2227,8 +2229,11 @@ fn lower_module_threads(
                         ExprKind::Literal(LitKind::Dec(for_cnt_width as u64)),
                         sp,
                     ))),
-                    init: Some(make_zero_expr(sp)),
-                    reset: RegReset::None,
+                    init: None, // reset-initialised; no declaration initializer (issue #995)
+                    reset: RegReset::Inherit(
+                        Ident::new(t.reset.name.clone(), sp),
+                        make_zero_expr(sp),
+                    ),
                     guard: None,
                     multicycle: None,
                     span: sp,

--- a/src/elaborate/tlm.rs
+++ b/src/elaborate/tlm.rs
@@ -3557,8 +3557,8 @@ fn inline_lower_tlm_initiator_group(
             items.push(ModuleBodyItem::RegDecl(RegDecl {
                 name: mk_ident(counter.clone()),
                 ty: TypeExpr::UInt(Box::new(dec(32))),
-                init: Some(dec(0)),
-                reset: RegReset::None,
+                init: None, // reset-initialised, no declaration initializer (issue #995)
+                reset: RegReset::Inherit(rst.clone(), dec(0)),
                 guard: None,
                 multicycle: None,
                 span,
@@ -6543,8 +6543,11 @@ fn inline_lower_tlm_target_with_io(
                 ExprKind::Literal(LitKind::Dec(cnt_width as u64)),
                 span,
             ))),
-            init: Some(Expr::new(ExprKind::Literal(LitKind::Dec(0)), span)),
-            reset: RegReset::None,
+            init: None, // reset-initialised, no declaration initializer (issue #995)
+            reset: RegReset::Inherit(
+                t.reset.clone(),
+                Expr::new(ExprKind::Literal(LitKind::Dec(0)), span),
+            ),
             guard: None,
             multicycle: None,
             span,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21436,9 +21436,11 @@ fn test_tight_relock_release_event_is_registered_709() {
         end module SemaphoreRelock709
     "#;
     let sv = compile_to_sv(source);
+    // The release flag is a reset register: declared without an initializer
+    // (issue #995, PROCASSINIT) and cleared in the reset branch.
     assert!(
-        sv.contains("logic _pool_release_0 = 0"),
-        "lock release must be a registered signal with an initializer:\n{sv}"
+        sv.contains("logic _pool_release_0;") && sv.contains("_pool_release_0 <= 0;"),
+        "lock release must be a registered signal cleared by reset:\n{sv}"
     );
     assert!(
         sv.contains("_pool_release_0 <= 1")
@@ -40297,4 +40299,59 @@ end module BpTop2
     let sv = compile_to_sv(src);
     assert!(sv.contains(".m_req_valid(v)"), "{sv}");
     assert!(sv.contains(".m_req_ready(r)"), "{sv}");
+}
+
+#[test]
+fn test_thread_regs_have_no_declaration_initializer_issue_995() {
+    // Issue #995: the lowered thread state register and its cycle / loop
+    // counters were declared with an initializer *and* driven procedurally,
+    // which Verilator -Wall reports as PROCASSINIT. They all have the
+    // thread's reset, so the reset branch must be their only initialisation.
+    let source = r#"
+domain SysDomain
+  freq_mhz: 100
+end domain SysDomain
+
+module thread_procassinit
+  port clk:   in  Clock<SysDomain>;
+  port rst:   in  Reset<Async, Low>;
+  port go_i:  in  Bool;
+  port ack_i: in  Bool;
+  port v_o:   out Bool;
+  thread T on clk rising, rst low
+    default comb
+      v_o = false;
+    end default
+    if not go_i
+      wait until go_i;
+    end if
+    wait 2 cycle;
+    for i in 0..3
+      wait 1 cycle;
+    end for
+    do
+      v_o = true;
+    until ack_i;
+  end thread T
+end module thread_procassinit
+"#;
+    let sv = compile_to_sv(source);
+    for reg in ["_t0_state", "_t0_cnt", "_t0_loop_cnt_0"] {
+        let decl_with_init = sv
+            .lines()
+            .any(|l| l.contains(&format!(" {reg} = ")) && l.trim_start().starts_with("logic"));
+        assert!(
+            !decl_with_init,
+            "{reg} must not carry a declaration initializer (PROCASSINIT, #995):\n{sv}"
+        );
+        assert!(
+            sv.contains(&format!("{reg} <= ")),
+            "{reg} must be driven in the always_ff:\n{sv}"
+        );
+    }
+    // The counters now sit in the thread's reset branch.
+    assert!(
+        sv.contains("negedge rst"),
+        "thread block must be reset by rst:\n{sv}"
+    );
 }


### PR DESCRIPTION
Closes #995.

**Problem.** Verilator `-Wall` reports `PROCASSINIT` for compiler-generated registers that carry a declaration initializer and are also driven in the `always_ff`: the lowered `thread` state register, the lock `_<res>_release_N` / `_<res>_held_N` flags and the TLM initiator state (all declared `init 0` *and* reset by the thread's reset), plus the thread and TLM cycle/loop counters (`init 0`, no reset). arch-ibex's `make lint` fails on the two counters in `ibex_multdiv_fast.sv`.

**Fix — lowering only.** The design source never wrote an `init`, so the lowering must not introduce one:
- `elaborate/threads.rs`: state, release and held registers keep their inherited reset and drop the generated `init`; `_t{n}_cnt` and `_t{n}_loop_cnt_{k}` inherit the thread's reset (value 0) instead of an initializer.
- `elaborate/tlm.rs`: the initiator and target loop counters likewise inherit the reset already used by their sibling state / wait-count registers.

No compiler-generated register carries an `init` any more (`grep 'init: Some(' src/elaborate` → 0). User-written `init` keeps its documented meaning (the SV declaration initializer) and the SV backend is untouched, so the existing SV snapshots are unchanged.

**Tests.** New `test_thread_regs_have_no_declaration_initializer_issue_995` (the issue's reproducer plus `wait N cycle` and a `for`); `test_tight_relock_release_event_is_registered_709` now asserts the reset-branch form for the release flag. `cargo test --release` green (all suites).

**Verification.** The issue reproducer lints clean (`verilator --lint-only -Wall` → 0 `PROCASSINIT`, was 1). arch-ibex `make lint` with this build drops from 3 warnings to 1 (the unrelated `SYNCASYNCNET`); `build/ibex_multdiv_fast.sv` now declares `_t0_state` / `_t0_loop_cnt_0` without initializers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)