### PR TITLE
sim(pybind): bind flat Vec-port elements through accessors (closes #996)

### DIFF
--- a/src/sim_codegen/pybind.rs
+++ b/src/sim_codegen/pybind.rs
@@ -411,14 +411,21 @@ impl<'a> SimCodegen<'a> {
             port_info.push((field.clone(), width, is_signed, is_input, false, false));
         }
 
-        // Vec port flattened fields
+        // Vec port flattened fields. `{base}_{i}` is a *reference* member
+        // aliasing `{base}[i]` in the model struct; a pointer-to-member cannot
+        // be formed for a reference (issue #996: "cannot form a pointer-to-member
+        // to member of reference type"), so bind through accessor lambdas
+        // instead of `def_readwrite`. Elements wider than 64 bits use the
+        // VlWide lambdas like scalar wide ports.
         for (base_name, _elem_ty, count, is_input) in &vec_port_infos {
             let width = self.vec_elem_width(&m.ports, base_name);
             for i in 0..*count {
                 let field = format!("{base_name}_{i}");
-                bindings.push(format!(
-                    "        .def_readwrite(\"{field}\", &{class}::{field})"
-                ));
+                if width > 64 {
+                    bindings.push(self.emit_wide_binding(&class, &field, width));
+                } else {
+                    bindings.push(self.emit_ref_binding(&class, &field));
+                }
                 port_info.push((field, width, false, *is_input, false, false));
             }
         }
@@ -628,6 +635,7 @@ auto {helper_name}(const T& self) {{
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <cstdint>
+#include <type_traits>
 #include "{class}.h"
 namespace py = pybind11;
 
@@ -756,6 +764,17 @@ PYBIND11_MODULE({pybind_module}, m) {{
     }
 
     /// Emit a lambda-based pybind11 binding for a VlWide field.
+    /// Bind a reference member (a flat Vec element aliasing `base[i]`) through
+    /// accessor lambdas; `def_readwrite` needs a pointer-to-member, which does
+    /// not exist for references (issue #996).
+    fn emit_ref_binding(&self, class: &str, field: &str) -> String {
+        format!(
+            r#"        .def_property("{field}",
+            []({class}& self) {{ return self.{field}; }},
+            []({class}& self, std::decay_t<decltype(self.{field})> value) {{ self.{field} = value; }})"#,
+        )
+    }
+
     fn emit_wide_binding(&self, class: &str, field: &str, width: u32) -> String {
         format!(
             r#"        .def_property("{field}",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -40355,3 +40355,47 @@ end module thread_procassinit
         "thread block must be reset by rst:\n{sv}"
     );
 }
+
+#[test]
+fn test_pybind_vec_port_elements_bind_through_accessors_issue_996() {
+    // Issue #996: flat Vec-port elements are reference members
+    // (`uint32_t& v_i_0`), for which `def_readwrite` cannot form a
+    // pointer-to-member; they must be bound through accessor lambdas.
+    let source = r"
+        domain SysDomain
+          freq_mhz: 100
+        end domain SysDomain
+
+        module VecPorts
+          port clk: in Clock<SysDomain>;
+          port v_i: in Vec<UInt<32>, 2>;
+          port w_i: in Vec<UInt<34>, 2>;
+          port v_o: out Vec<UInt<32>, 2>;
+          comb
+            v_o[0] = v_i[1];
+            v_o[1] = v_i[0] + w_i[0].trunc<32>();
+          end comb
+        end module VecPorts
+    ";
+    let pybinds = compile_to_pybind_cpps(source);
+    let cpp = pybinds
+        .iter()
+        .find(|(n, _)| n.contains("VecPorts"))
+        .expect("VecPorts pybind wrapper")
+        .1
+        .clone();
+    for field in ["v_i_0", "v_i_1", "w_i_0", "w_i_1", "v_o_0", "v_o_1"] {
+        assert!(
+            !cpp.contains(&format!(".def_readwrite(\"{field}\"")),
+            "{field} must not use def_readwrite on a reference member (#996):\n{cpp}"
+        );
+        assert!(
+            cpp.contains(&format!(".def_property(\"{field}\"")),
+            "{field} must be bound through def_property accessors:\n{cpp}"
+        );
+    }
+    assert!(
+        cpp.contains("#include <type_traits>"),
+        "std::decay_t needs <type_traits>:\n{cpp}"
+    );
+}


### PR DESCRIPTION
Closes #996.

**Problem.** `arch sim --pybind` on a module with a `Vec<T, N>` port generates per-element *reference* members (`uint32_t& imd_val_q_i_0` aliasing `imd_val_q_i[0]`) and binds them with `def_readwrite`, which needs a pointer-to-member; clang rejects it for a reference type, so the wrapper never compiles. arch-ibex's six `test_archsim_units` cases (any module with a Vec port) fail on it.

**Fix.** `sim_codegen/pybind.rs`: the flat Vec elements are bound with `def_property` getter/setter lambdas over the reference member (`std::decay_t<decltype(self.field)>` for the setter argument, `<type_traits>` added to the generated includes); elements wider than 64 bits use the existing VlWide lambdas. No change to the generated model or to scalar/bus ports.

**Tests.** New `test_pybind_vec_port_elements_bind_through_accessors_issue_996` (32- and 34-bit Vec ports; asserts `def_property` and no `def_readwrite` for every element). `cargo test --release` green.

**Verification.** arch-ibex `pytest tests/test_archsim_units.py` with this build: the wrapper compiles for all six modules; IbexAlu, IbexCounter, IbexDecoder, IbexMultdivFast and IbexRegisterFileFf run their cocotb suites green (the harness only needed to accept the 0.72 runtime's `Results: N tests; N passed, 0 failed` footer instead of the old `ALL PASSED`). IbexCompressedDecoder compiles and runs 28/29; the remaining failure is a native-simulator semantic difference on a multi-cycle Zcmp expansion that Verilator passes — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)