### PR TITLE
Prepare ARCH 0.72.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arch"
-version = "0.72.1"
+version = "0.72.2"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arch"
-version = "0.72.1"
+version = "0.72.2"
 edition = "2021"
 description = "Compiler for the ARCH hardware description language"
 license = "LGPL-3.0-or-later"

--- a/doc/COMPILER_STATUS.md
+++ b/doc/COMPILER_STATUS.md
@@ -1,7 +1,10 @@
 # ARCH Compiler — Status & Roadmap
 
 > Last updated: 2026-09-05
-> Compiler version: 0.72.1
+> Compiler version: 0.72.2
+>
+> **0.72.2 release highlights:**
+> - **Native simulator: module-scope `let`s that read comb-assigned signals are evaluated after the `comb` blocks** (#1003, PR #1005) — `eval_comb()` emitted every module-scope `let` before the comb blocks, so a `let` such as `let instr_o = instr_d;` carried the previous pass's value; with input-only changes `eval()`'s second comb pass hid it, but across a clock edge the output lagged the state register by one cycle while Verilator on the same SV was right. Lets that (transitively) read a comb-assigned signal are now emitted after the comb blocks; other modules' C++ is byte-identical. Found on arch-ibex's compressed decoder (Zcmp `cm.push` walk, now 29 / 29 under `arch sim --pybind`).
 >
 > **0.72.1 release highlights:**
 > - **No compiler-introduced declaration initializers** (#995, PR #1001) — the lowered `thread` state register, the lock `release`/`held` flags, the TLM initiator state and the thread/TLM cycle and loop counters no longer carry a `= 0` declaration initializer alongside their procedural driver; the reset-owned registers rely on the reset branch and the counters now inherit the thread's reset. Verilator `-Wall` no longer reports `PROCASSINIT` on any `thread` design. User-written `init` keeps its documented meaning (the SV declaration initializer).

--- a/skills/arch-programming/references/COMPILER_STATUS.md
+++ b/skills/arch-programming/references/COMPILER_STATUS.md
@@ -1,7 +1,10 @@
 # ARCH Compiler — Status & Roadmap
 
 > Last updated: 2026-09-05
-> Compiler version: 0.72.1
+> Compiler version: 0.72.2
+>
+> **0.72.2 release highlights:**
+> - **Native simulator: module-scope `let`s that read comb-assigned signals are evaluated after the `comb` blocks** (#1003, PR #1005) — `eval_comb()` emitted every module-scope `let` before the comb blocks, so a `let` such as `let instr_o = instr_d;` carried the previous pass's value; with input-only changes `eval()`'s second comb pass hid it, but across a clock edge the output lagged the state register by one cycle while Verilator on the same SV was right. Lets that (transitively) read a comb-assigned signal are now emitted after the comb blocks; other modules' C++ is byte-identical. Found on arch-ibex's compressed decoder (Zcmp `cm.push` walk, now 29 / 29 under `arch sim --pybind`).
 >
 > **0.72.1 release highlights:**
 > - **No compiler-introduced declaration initializers** (#995, PR #1001) — the lowered `thread` state register, the lock `release`/`held` flags, the TLM initiator state and the thread/TLM cycle and loop counters no longer carry a `= 0` declaration initializer alongside their procedural driver; the reset-owned registers rely on the reset branch and the counters now inherit the thread's reset. Verilator `-Wall` no longer reports `PROCASSINIT` on any `thread` design. User-written `init` keeps its documented meaning (the SV declaration initializer).


### PR DESCRIPTION
Bumps the crate version to 0.72.2 (`Cargo.toml`, `Cargo.lock`) and adds the `COMPILER_STATUS.md` banner and highlights block. Once merged, the annotated tag `v0.72.2` on the merge commit triggers the cargo-dist release workflow.

**What ships since v0.72.1:** #1005 — native simulator: module-scope lets that read comb-assigned signals are evaluated after the comb blocks (closes #1003). Outputs derived from a register through a comb wire and a `let` no longer lag by one cycle under `arch sim`; arch-ibex's compressed decoder cocotb suite is 29 / 29 under `--pybind`.

Patch bump: simulator-backend fix only, no language or SV-emission change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)