### PR TITLE
learn: lock the store and rewrite it atomically so concurrent checks cannot wipe events.jsonl (closes #1008)

### DIFF
--- a/src/learn.rs
+++ b/src/learn.rs
@@ -56,6 +56,38 @@ pub fn learn_dir() -> std::io::Result<PathBuf> {
     Ok(dir)
 }
 
+/// Exclusive advisory lock over the whole store (`<learn_dir>/.lock`), held for the
+/// duration of any append or read-modify-write of `events.jsonl`, `index.json` or
+/// `retrieval_counts.json`. Released when the guard drops (the OS releases it on
+/// process exit too). Blocking, so concurrent `arch check`/`arch build` processes
+/// queue instead of racing: without this, a rewrite done as truncate+write could be
+/// read half-written by a sibling process, which then wrote that empty view back
+/// and wiped the store (issue #1008).
+struct StoreLock(#[allow(dead_code)] fs::File);
+
+fn lock_store(dir: &std::path::Path) -> std::io::Result<StoreLock> {
+    let f = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(dir.join(".lock"))?;
+    f.lock()?;
+    Ok(StoreLock(f))
+}
+
+/// Replace `path` atomically: write a sibling temp file, then rename it over the
+/// target, so a reader never observes a truncated or half-written file.
+fn write_atomic(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+    let tmp = path.with_file_name(format!(
+        ".{}.tmp.{}",
+        path.file_name().and_then(|n| n.to_str()).unwrap_or("store"),
+        std::process::id()
+    ));
+    fs::write(&tmp, contents)?;
+    fs::rename(&tmp, path)
+}
+
 /// Is learning capture enabled? Honors `ARCH_NO_LEARN=1` as an opt-out.
 pub fn is_enabled() -> bool {
     match std::env::var("ARCH_NO_LEARN") {
@@ -319,7 +351,7 @@ pub fn record_failure(
         error_message: error_message.to_string(),
         src: src.to_string(),
     };
-    fs::write(&pending_file, pending_to_json(&pending))?;
+    write_atomic(&pending_file, &pending_to_json(&pending))?;
     Ok(())
 }
 
@@ -380,6 +412,12 @@ pub fn record_success_if_pending(
 
 fn append_event(e: &Event) -> std::io::Result<()> {
     let dir = learn_dir()?;
+    let _lock = lock_store(&dir)?;
+    append_event_unlocked(&dir, e)
+}
+
+/// Append with the store lock already held by the caller.
+fn append_event_unlocked(dir: &std::path::Path, e: &Event) -> std::io::Result<()> {
     let path = dir.join("events.jsonl");
     let mut f = fs::OpenOptions::new()
         .create(true)
@@ -471,14 +509,18 @@ where
         return Ok(0);
     }
 
-    // Replace any existing feature events for the files we're harvesting.
+    // Replace any existing feature events for the files we're harvesting. Purge and
+    // re-append under one store lock so a sibling process can neither interleave its
+    // events between the two steps nor read the file mid-rewrite (#1008).
     let touched_files: std::collections::HashSet<String> =
         new_events.iter().map(|e| e.file_path.clone()).collect();
-    purge_features_for_files(&touched_files)?;
+    let dir = learn_dir()?;
+    let _lock = lock_store(&dir)?;
+    purge_features_for_files(&dir, &touched_files)?;
 
     let mut count = 0;
     for e in &new_events {
-        append_event(e)?;
+        append_event_unlocked(&dir, e)?;
         count += 1;
     }
     Ok(count)
@@ -498,9 +540,12 @@ fn extract_doc(item: &crate::ast::Item) -> Option<(&'static str, String, String,
 }
 
 /// Remove all feature events whose `file_path` matches any of `files`.
-/// Rewrites `events.jsonl` by line-filtering. O(N) per call.
-fn purge_features_for_files(files: &std::collections::HashSet<String>) -> std::io::Result<()> {
-    let dir = learn_dir()?;
+/// Rewrites `events.jsonl` by line-filtering. O(N) per call. The caller must
+/// hold the store lock; the rewrite itself is atomic (temp file + rename).
+fn purge_features_for_files(
+    dir: &std::path::Path,
+    files: &std::collections::HashSet<String>,
+) -> std::io::Result<()> {
     let path = dir.join("events.jsonl");
     if !path.exists() {
         return Ok(());
@@ -524,12 +569,13 @@ fn purge_features_for_files(files: &std::collections::HashSet<String>) -> std::i
     if !out.is_empty() {
         out.push('\n');
     }
-    fs::write(&path, out)
+    write_atomic(&path, &out)
 }
 
 /// Build / rebuild the BM25 index over events.jsonl. Writes index.json.
 pub fn build_index() -> std::io::Result<usize> {
     let dir = learn_dir()?;
+    let _lock = lock_store(&dir)?;
     let events_path = dir.join("events.jsonl");
     if !events_path.exists() {
         eprintln!(
@@ -579,7 +625,7 @@ pub fn build_index() -> std::io::Result<usize> {
         out.push_str(&format!("\"{}\":{}", escape_json_string(term), count));
     }
     out.push_str("}}");
-    fs::write(&index_path, out)?;
+    write_atomic(&index_path, &out)?;
     Ok(n_docs)
 }
 
@@ -650,13 +696,14 @@ fn save_counts(counts: &std::collections::HashMap<String, u32>) -> std::io::Resu
         s.push_str(&format!("\"{}\":{}", k, v));
     }
     s.push('}');
-    fs::write(&path, s)
+    write_atomic(&path, &s)
 }
 
 fn bump_counts(ids: &[String]) -> std::io::Result<()> {
     if ids.is_empty() {
         return Ok(());
     }
+    let _lock = lock_store(&learn_dir()?)?;
     let mut counts = load_counts()?;
     for id in ids {
         *counts.entry(id.clone()).or_insert(0) += 1;
@@ -804,6 +851,7 @@ pub fn prune(
     dry_run: bool,
 ) -> std::io::Result<(usize, usize)> {
     let dir = learn_dir()?;
+    let _lock = lock_store(&dir)?;
     let events_path = dir.join("events.jsonl");
     if !events_path.exists() {
         return Ok((0, 0));
@@ -867,7 +915,7 @@ pub fn prune(
         if !out.is_empty() {
             out.push('\n');
         }
-        fs::write(&events_path, out)?;
+        write_atomic(&events_path, &out)?;
         // Index is now stale; remove so `advise` rebuilds / warns.
         let _ = fs::remove_file(dir.join("index.json"));
     }
@@ -1277,6 +1325,46 @@ mod tests {
         // Skipping it would silently disable capture for that project.
         assert!(!is_unmatchable_path("/home/dev/temp/myproj/Foo.arch"));
         assert!(!is_unmatchable_path("/Users/dev/Documents/tempo/Foo.arch"));
+    }
+
+    #[test]
+    fn write_atomic_replaces_without_leaving_temp_files() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let p = td.path().join("events.jsonl");
+        write_atomic(&p, "a\n").expect("first write");
+        write_atomic(&p, "b\nc\n").expect("second write");
+        assert_eq!(fs::read_to_string(&p).expect("read"), "b\nc\n");
+        let leftovers: Vec<_> = fs::read_dir(td.path())
+            .expect("read_dir")
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.contains(".tmp."))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp files left behind: {leftovers:?}"
+        );
+    }
+
+    #[test]
+    fn store_lock_is_exclusive_across_handles() {
+        // A second lock on the same store must wait for the first guard to drop.
+        let td = tempfile::tempdir().expect("tempdir");
+        let dir = td.path().to_path_buf();
+        let guard = lock_store(&dir).expect("lock");
+        let dir2 = dir.clone();
+        let t = std::thread::spawn(move || {
+            let start = std::time::Instant::now();
+            let _g = lock_store(&dir2).expect("second lock");
+            start.elapsed()
+        });
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        drop(guard);
+        let waited = t.join().expect("join");
+        assert!(
+            waited >= std::time::Duration::from_millis(200),
+            "second lock did not wait for the first: {waited:?}"
+        );
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -40443,3 +40443,93 @@ fn test_sim_let_reading_comb_wire_emitted_after_comb_blocks_issue_1003() {
         "`let y_o = d` must be evaluated after the comb block that assigns d (#1003):\n{comb}"
     );
 }
+
+// ── Learning store: concurrent writers must not corrupt or wipe events.jsonl (#1008) ─
+
+#[test]
+fn test_learn_store_survives_concurrent_checks_issue_1008() {
+    // Before the fix, `harvest_features` rewrote events.jsonl with truncate+write and no
+    // lock; a sibling `arch check` reading mid-rewrite saw an empty file and wrote that
+    // back, wiping every earlier event. Reproduce the pattern: pre-fill a store, then run
+    // many checks of a doc-commented file at once under the same HOME.
+    let home = tempfile::tempdir().expect("tempdir");
+    let src = home.path().join("Doc.arch");
+    std::fs::write(
+        &src,
+        r#"
+        /// A documented module: the harvester records one feature event for it.
+        module Doc
+          port a: in Bool;
+          port y: out Bool;
+          let y = a;
+        end module Doc
+    "#,
+    )
+    .expect("write source");
+    let learn_dir = home.path().join(".arch").join("learn");
+    std::fs::create_dir_all(learn_dir.join("pending")).expect("mkdir learn");
+    let events = learn_dir.join("events.jsonl");
+    let mut prefill = String::new();
+    for i in 0..2000 {
+        prefill.push_str(&format!(
+            "{{\"ts\":\"2026-01-01T00:00:00Z\",\"kind\":\"error_fix\",\"error_code\":\"E{i}\",\"error_message\":\"{}\",\"file_path\":\"/old/{i}.arch\",\"src_before\":\"\",\"src_after\":\"\",\"diff_summary\":\"\"}}\n",
+            "x".repeat(300)
+        ));
+    }
+    std::fs::write(&events, &prefill).expect("prefill");
+
+    for _round in 0..3 {
+        let children: Vec<_> = (0..8)
+            .map(|_| {
+                std::process::Command::new(env!("CARGO_BIN_EXE_arch"))
+                    .env("HOME", home.path())
+                    .env_remove("ARCH_NO_LEARN")
+                    .arg("check")
+                    .arg(&src)
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn()
+                    .expect("spawn arch check")
+            })
+            .collect();
+        for mut c in children {
+            assert!(c.wait().expect("wait").success(), "arch check failed");
+        }
+    }
+
+    let raw = std::fs::read_to_string(&events).expect("read events");
+    let lines: Vec<&str> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+    let kept = lines
+        .iter()
+        .filter(|l| l.contains("\"kind\":\"error_fix\""))
+        .count();
+    assert_eq!(
+        kept, 2000,
+        "pre-existing events were lost: {} of 2000 remain",
+        kept
+    );
+    let features = lines
+        .iter()
+        .filter(|l| l.contains("\"kind\":\"feature\""))
+        .count();
+    assert_eq!(
+        features, 1,
+        "expected exactly one feature event for Doc, found {features}"
+    );
+    for l in &lines {
+        assert!(
+            l.starts_with('{') && l.ends_with('}') && l.matches("\"ts\":").count() == 1,
+            "interleaved or truncated line: {l}"
+        );
+    }
+    let leftovers: Vec<_> = std::fs::read_dir(&learn_dir)
+        .expect("read_dir")
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n.contains(".tmp."))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "temp files left behind: {leftovers:?}"
+    );
+}


### PR DESCRIPTION
Fixes #1008.

## Problem
`harvest_features()` (every `arch check`/`arch build` of a doc-commented file) rewrote `~/.arch/learn/events.jsonl` with truncate+write and no lock. Concurrent arch processes under one `$HOME` raced on it; on 2026-09-06 five parallel checks reduced a 16 MB / 10,036-event store to a few interleaved lines.

## Fix (internal; no language, CLI or output change)
- Exclusive advisory lock on `<learn_dir>/.lock` (`std::fs::File::lock`) around every append and read-modify-write of `events.jsonl`, `index.json`, `retrieval_counts.json`; `harvest_features` does its purge + re-append as one critical section.
- All rewrites via temp file + rename (`write_atomic`), so readers never see a truncated file. Readers stay lock-free.
- Pending failure records written atomically too.

## Verification
- `cargo test --lib learn::` (10 passed, incl. new `write_atomic_replaces_without_leaving_temp_files`, `store_lock_is_exclusive_across_handles`).
- New integration test `test_learn_store_survives_concurrent_checks_issue_1008`: 2000-event store + 24 concurrent checks → all events kept, one feature event, no interleaving, no temp files.
- Manual repro, 3 rounds × 9 concurrent runs on a 2.4 MB store: unpatched 0.72.2 → 2 KB left; this branch → byte-identical.
- `cargo fmt --check` clean; clippy adds nothing (remaining learn.rs notes are pre-existing).
- Full `cargo test --release` running as the long verification; follow-up commits if it turns anything up.

Found during the TASK5 benchmark regeneration. The benchmark keeps its 0.72.2 pin and runs the pinned binary behind an external flock wrapper; this fix is for future releases.