### PR TITLE
codegen+sim: preserve signedness of `.sext<N>()` / signed `.resize<N>()` (closes #1010)

### DIFF
--- a/src/codegen/method_call.rs
+++ b/src/codegen/method_call.rs
@@ -141,7 +141,17 @@ impl<'a> Codegen<'a> {
                         self.push_hoist_temp_in_loop(sw.clone(), tmp.clone(), rb, in_loop);
                         tmp
                     };
-                    format!("{{{{({w}-{sw}){{{rb}[{sw}-1]}}}}, {rb}}}")
+                    // arch#1010: `.sext<N>()` is typed `SInt<N>` by the type
+                    // checker, but a bare SV concatenation is *unsigned*
+                    // (IEEE 1800 §11.8.1) regardless of operand signedness —
+                    // so a signedness-sensitive operator fed by this result
+                    // (relational compare, arithmetic `>>>`, `/`, `%`)
+                    // evaluates unsigned and gives the wrong answer. Wrap the
+                    // concat in `$signed(...)` so the result carries the
+                    // signedness the front end already committed to. The bits
+                    // are unchanged, so `+`/`-`/`*` and assignment targets are
+                    // unaffected; only the SV signedness attribute is restored.
+                    format!("$signed({{{{({w}-{sw}){{{rb}[{sw}-1]}}}}, {rb}}})")
                 } else {
                     b
                 }

--- a/src/sim_codegen/expr_codegen.rs
+++ b/src/sim_codegen/expr_codegen.rs
@@ -809,11 +809,12 @@ pub(super) fn infer_expr_signed(expr: &Expr, ctx: &Ctx) -> bool {
         ExprKind::Cast(_, ty) => matches!(ty.as_ref(), TypeExpr::SInt(_)),
         ExprKind::Signed(_) => true,
         ExprKind::Unsigned(_) => false,
+        // `.sext<N>()` is typed `SInt<N>` unconditionally by the type checker
+        // (typecheck.rs), regardless of the receiver's signedness — so its
+        // result is always signed (arch#1010).
+        ExprKind::MethodCall(_, method, _) if method.name == "sext" => true,
         ExprKind::MethodCall(base, method, _)
-            if matches!(
-                method.name.as_str(),
-                "trunc" | "sext" | "resize" | "reverse"
-            ) =>
+            if matches!(method.name.as_str(), "trunc" | "resize" | "reverse") =>
         {
             infer_expr_signed(base, ctx)
         }
@@ -1874,7 +1875,7 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
             if let Some(w_expr) = args.first() {
                 let dst_bits = eval_width_in(w_expr, ctx);
                 let src_bits = infer_expr_width(base, ctx);
-                if src_bits >= dst_bits || src_bits == 0 {
+                let value = if src_bits >= dst_bits || src_bits == 0 {
                     // No extension needed or unknown source width
                     format!("({})({})", cpp_uint(dst_bits), b)
                 } else {
@@ -1882,22 +1883,49 @@ pub(super) fn cpp_method_call(base: &Expr, method: &Ident, args: &[Expr], ctx: &
                     let dst_t = cpp_uint(dst_bits);
                     format!("(({b} >> {}) & 1 ? ({dst_t})({b}) | ({dst_t})(~(({dst_t})0) << {src_bits}) : ({dst_t})({b}))",
                         src_bits - 1)
+                };
+                // arch#1010: `.sext<N>()` is typed `SInt<N>` (typecheck.rs),
+                // but the value above is an unsigned C++ type, so a downstream
+                // comparison or arithmetic right shift evaluates unsigned (C++
+                // usual-arithmetic-conversions) and gives the wrong answer —
+                // matching the SV concat defect. Reinterpret the (correct)
+                // sign-extended bit pattern as a signed C++ value so the
+                // signedness the front end committed to is preserved. Scalar
+                // widths only; wide (>64b) sext keeps its existing form.
+                if dst_bits > 0 && dst_bits <= 64 {
+                    cast_to_signed_bits(&value, dst_bits)
+                } else {
+                    value
                 }
             } else {
                 b
             }
         }
         "resize" => {
-            // Direction-agnostic: sign-extend if narrowing to signed, zero-pad if widening unsigned
+            // Direction-agnostic: preserves the source's signedness (matching
+            // the SV `N'(expr)` size cast).
             if let Some(w_expr) = args.first() {
                 let dst_bits = eval_width_in(w_expr, ctx);
                 let src_bits = infer_expr_width(base, ctx);
-                if src_bits >= dst_bits || src_bits == 0 {
+                let signed = infer_expr_signed(base, ctx);
+                let value = if src_bits >= dst_bits || src_bits == 0 {
                     // Narrowing or equal: just cast (C++ truncates)
                     cast_to_bits(&b, dst_bits)
                 } else {
-                    // Widening: zero-extend (same as zext for sim purposes)
+                    // Widening: zero-extend (same as zext for sim purposes).
+                    // For a signed source the C++ signed-wrap below restores
+                    // the sign, and integer promotion of a signed base already
+                    // sign-extends the value bits.
                     format!("({})({})", cpp_uint(dst_bits), b)
+                };
+                // arch#1010: when the HDL result is signed, reinterpret as a
+                // signed C++ value so downstream comparisons / right shifts are
+                // signed — the SV backend already sign-preserves via `N'(x)`,
+                // and `arch sim` diverged here. Scalar widths only.
+                if signed && dst_bits > 0 && dst_bits <= 64 {
+                    cast_to_signed_bits(&value, dst_bits)
+                } else {
+                    value
                 }
             } else {
                 b

--- a/src/sim_codegen/pipeline.rs
+++ b/src/sim_codegen/pipeline.rs
@@ -1645,7 +1645,7 @@ impl<'a> SimCodegen<'a> {
                             let dst_bits = eval_const_expr_with_params(width, params) as u32;
                             let src_bits =
                                 self.pipeline_sim_expr_width(base, prefix, si, srn, w, pn, params);
-                            if src_bits >= dst_bits || src_bits == 0 {
+                            let value = if src_bits >= dst_bits || src_bits == 0 {
                                 format!("({})({b})", cpp_uint(dst_bits))
                             } else {
                                 let dst_ty = cpp_uint(dst_bits);
@@ -1653,6 +1653,15 @@ impl<'a> SimCodegen<'a> {
                                     "((({b} >> {}) & 1) ? ({dst_ty})({b}) | ({dst_ty})(~(({dst_ty})0) << {src_bits}) : ({dst_ty})({b}))",
                                     src_bits - 1,
                                 )
+                            };
+                            // arch#1010: `.sext<N>()` is `SInt<N>`; reinterpret
+                            // the sign-extended bit pattern as signed so a
+                            // downstream compare / arithmetic `>>` in the same
+                            // stage evaluates signed. Scalar widths only.
+                            if dst_bits > 0 && dst_bits <= 64 {
+                                cast_to_signed_bits(&value, dst_bits)
+                            } else {
+                                value
                             }
                         } else {
                             b

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -36659,6 +36659,138 @@ end module SextOfSignedCast
     );
 }
 
+/// arch#1010: `.sext<N>()` is typed `SInt<N>`, but a bare SV concatenation is
+/// unsigned (IEEE 1800 §11.8.1) and the sim emitted an unsigned C++ value — so
+/// a signedness-sensitive operator fed by the result (relational compare,
+/// arithmetic `>>`) evaluated unsigned in BOTH backends and both agreed on the
+/// wrong answer. Shape check: SV wraps the concat in `$signed(...)`, and the
+/// sim reinterprets the pattern as a signed C++ scalar. `.resize<N>()` on a
+/// signed source gets the same signed reinterpret in sim (the SV size cast
+/// `N'(x)` already preserved signedness — the backends only diverged in sim).
+#[test]
+fn test_sext_result_carries_signedness_both_backends() {
+    let source = r#"
+module QSext
+  port a: in SInt<16>;
+  port b: in SInt<16>;
+  port lt_sext:  out Bool;
+  port shr_sext: out SInt<32>;
+  let wa: SInt<32> = a.sext<32>();
+  let lt_sext  = wa < b.sext<32>();
+  let shr_sext = a.sext<32>() >> 4;
+end module QSext
+"#;
+    let sv = compile_to_sv(source);
+    // The concat is wrapped in $signed so the compare / >>> are signed.
+    assert!(
+        sv.contains("$signed({{(32-16){a[16-1]}}, a})"),
+        "sext should emit a $signed-wrapped concat, got:\n{sv}"
+    );
+    // No bare unsigned concat left as a comparison / shift operand.
+    assert!(
+        !sv.contains("wa < {{") && !sv.contains("}, a} >>>"),
+        "no bare unsigned concat should feed a signed operator, got:\n{sv}"
+    );
+    let sim = compile_to_sim_h(source, false);
+    // The sim reinterprets the sign-extended pattern as int32_t so the compare
+    // and the arithmetic right shift are signed in C++.
+    assert!(
+        sim.contains("(int32_t)") && !sim.contains("lt_sext = (_let_wa < ((a >> 15)"),
+        "sim sext should reinterpret to a signed C++ scalar, got:\n{sim}"
+    );
+}
+
+/// arch#1010 behavioral: build the SV and run Verilator, asserting the
+/// spec-correct signed answers. A pre-fix run returns the exact opposite for
+/// the compares and a logical (zero-filled) shift. Skips if Verilator is
+/// absent, matching this file's Verilator-smoke convention.
+#[test]
+fn test_sext_signed_semantics_behavioral_verilator() {
+    let has_verilator = std::process::Command::new("verilator")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !has_verilator {
+        eprintln!("skipping arch#1010 sext signed-semantics behavioral check: verilator not found");
+        return;
+    }
+    let td = tempfile::tempdir().expect("tempdir");
+    let arch_src = td.path().join("QSextB.arch");
+    std::fs::write(
+        &arch_src,
+        r#"module QSextB
+  port a: in SInt<16>;
+  port b: in SInt<16>;
+  port lt_sext:  out Bool;
+  port shr_sext: out SInt<32>;
+  let lt_sext  = a.sext<32>() < b.sext<32>();
+  let shr_sext = a.sext<32>() >> 4;
+end module QSextB
+"#,
+    )
+    .expect("write arch");
+    let sv_out = td.path().join("QSextB.sv");
+    let arch_bin = env!("CARGO_BIN_EXE_arch");
+    let build = std::process::Command::new(arch_bin)
+        .arg("build")
+        .arg(&arch_src)
+        .arg("-o")
+        .arg(&sv_out)
+        .output()
+        .expect("build QSextB SV");
+    assert!(
+        build.status.success(),
+        "arch build should pass\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let tb = td.path().join("tb.cpp");
+    std::fs::write(
+        &tb,
+        r#"#include "VQSextB.h"
+#include "verilated.h"
+#include <cstdio>
+int main() {
+  { VQSextB* d = new VQSextB; d->a = (-1) & 0xFFFF; d->b = 1 & 0xFFFF; d->eval();
+    printf("A %d %d\n", (int)d->lt_sext, (int)d->shr_sext); delete d; }
+  { VQSextB* d = new VQSextB; d->a = 1 & 0xFFFF; d->b = (-1) & 0xFFFF; d->eval();
+    printf("B %d\n", (int)d->lt_sext); delete d; }
+  { VQSextB* d = new VQSextB; d->a = (-256) & 0xFFFF; d->eval();
+    printf("C %d\n", (int)d->shr_sext); delete d; }
+  return 0;
+}
+"#,
+    )
+    .expect("write tb");
+    let out = std::process::Command::new("verilator")
+        .args(["--cc", "--exe", "--build", "-Wno-fatal"])
+        .arg(&sv_out)
+        .arg(&tb)
+        .args(["--top-module", "QSextB", "-o", "vrun"])
+        .current_dir(td.path())
+        .output()
+        .expect("verilator build");
+    assert!(
+        out.status.success(),
+        "verilator build should pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let run = std::process::Command::new(td.path().join("obj_dir").join("vrun"))
+        .output()
+        .expect("run vrun");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    // -1 < 1 signed => 1 ; -1 >> 4 arithmetic => -1
+    assert!(
+        stdout.contains("A 1 -1"),
+        "expected `A 1 -1`, got:\n{stdout}"
+    );
+    // 1 < -1 signed => 0
+    assert!(stdout.contains("B 0"), "expected `B 0`, got:\n{stdout}");
+    // -256 >> 4 arithmetic => -16
+    assert!(stdout.contains("C -16"), "expected `C -16`, got:\n{stdout}");
+}
+
 /// Dual-simulator behavioral check for the arithmetic-index hoist
 /// (arch#650): the miscompiled pre-fix shape (`a - b[i]`) and the fixed
 /// shape (`(a - b)[i]` via a hoisted temp) both *compile* under Verilator


### PR DESCRIPTION
## Summary

Fixes **#1010** — a **common-mode miscompile**: `.sext<N>()` is typed `SInt<N>` by the type checker, but both backends dropped the signedness attribute at the operator level. Every signedness-sensitive operator fed by a sext result — relational compare (`< > <= >=`), arithmetic right shift, `/`, `%` — evaluated **unsigned**, and `arch build` and `arch sim` produced the *same* wrong answer. Because both backends agreed, the defect was invisible to every backend-vs-backend differential harness in the repo (backend_equiv, the nightly equivalence cron, `refactor_diff.sh`, #953, #752, #1007).

## Root cause

| Backend | Defect |
|---|---|
| SV (`arch build`) | `.sext<N>()` → bare concat `{{(N-W){x[W-1]}}, x}`; an SV concat is **unsigned** (IEEE 1800 §11.8.1), so a downstream `<` / `>>>` ran unsigned/logical. |
| Sim (`arch sim`) | sext produced a correctly sign-extended **value** but an unsigned C++ type → C++ usual-arithmetic-conversions made the compare unsigned. Same defect in the pipeline sim path. |
| Sim `.resize<N>()` (secondary finding) | signed source emitted an unsigned C++ value too → the one column where the backends **disagreed** (sim wrong, Verilator right). |

## Fix (internal codegen only — no user-facing syntax/semantics change)

The type checker already commits to `SInt<N>`; this only makes the emitters honor it.

- **SV**: wrap the sext concat in `$signed(...)`. Bits unchanged, so `+`/`-`/`*` and assignment targets are unaffected — only the signedness attribute is restored. iverilog- and Verilator-portable.
- **Sim**: reinterpret the sign-extended pattern as a signed C++ scalar via `cast_to_signed_bits` (scalar widths ≤64b) in both the main and pipeline expr emitters; same for `.resize<N>()` when the source is signed.
- `infer_expr_signed` now reports `.sext<N>()` as signed unconditionally (was recursing to the receiver), matching `typecheck.rs`.

## Verification

The issue's reproducer now yields spec-correct answers under **both** backends, and they agree:

| a | b | expr | spec | after |
|---|---|---|---|---|
| -1 | 1 | `a.sext<32>() < b.sext<32>()` | 1 | ✅ 1 |
| 1 | -1 | `a.sext<32>() < b.sext<32>()` | 0 | ✅ 0 |
| -1 | — | `a.sext<32>() >> 4` | -1 | ✅ -1 |
| -256 | — | `a.sext<32>() >> 4` | -16 | ✅ -16 |
| -1 | 1 | `a.resize<32>() < b.resize<32>()` | 1 | ✅ 1 (was sim=0) |

- Fast gate green: `cargo build --release`, `cargo fmt --check`, full suite **895 passed / 0 failed**.
- Two regression tests added: `test_sext_result_carries_signedness_both_backends` (both-backend shape) and `test_sext_signed_semantics_behavioral_verilator` (Verilator behavioral check of the signed compare + arithmetic shift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)